### PR TITLE
feat(step 5.3): wire selections into context reducer

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -54,7 +54,7 @@ An LLM or script can search for the tag, flip `[ ]` → `[x]`, and commit withou
 
 - [x] **5.1** Add `<ColumnSelector>` (X & Y dropdowns, skip empty headers). <!-- prompt:05-01 -->
 - [x] **5.2** Disable Y options if non-numeric. <!-- prompt:05-02 -->
-- [ ] **5.3** Wire selections into context reducer. <!-- prompt:05-03 -->
+- [x] **5.3** Wire selections into context reducer. <!-- prompt:05-03 -->
 - [ ] **5.4** RTL test: dropdown change updates chart. <!-- prompt:05-04 -->
 
 ---


### PR DESCRIPTION
# Wire selections into context reducer

Implements **task 5.3** – Wire column selections into the DatasetContext reducer

## Changes
- Verified existing implementation of column selection state management
- Confirmed working integration between ColumnSelector and DatasetContext
- Validated test coverage for selection changes

## Testing
- ✅ Unit tests passing
- ✅ E2E tests passing
- ✅ ESLint / type-check clean

## Related Tasks
- Completes 5.3 in *todo.md*
- Sets up foundation for 5.4 (RTL test for chart updates)

## Notes
- The implementation was already complete and working correctly
- Comprehensive test coverage exists for both unit and E2E scenarios
- The context reducer properly handles SET_KEYS actions with validation 