### PR TITLE
chore: ignore test report directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Test reports and results
+playwright-report/
+test-results/


### PR DESCRIPTION
Adds playwright-report/ and test-results/ directories to .gitignore to prevent generated test files from being tracked.